### PR TITLE
3 updates

### DIFF
--- a/KafkaExtractor/KafkaExtractor.csproj
+++ b/KafkaExtractor/KafkaExtractor.csproj
@@ -6,11 +6,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="1.2.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.0.1" />
+    <PackageReference Include="Confluent.Kafka" Version="1.4.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.6" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.6" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.6" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/KafkaExtractor/README.md
+++ b/KafkaExtractor/README.md
@@ -6,16 +6,20 @@ KakfaExtractor is a tool that can extract messages from Kafka. It retrieves mess
 
 appsettings.json is the setting file. Important setting items are as below.
 
-Extraction: settings about extraction
-Extraction.Path: path to which the data file is saved
-Extraction.FileName: filename of the data file, {} will be replaced with datetime of extraction
-Extraction.Filter: Only messages containing filter are saved while others are ignored. Not effective when partition list has 1 and offset list is not empty. If not specified or not effective, no messages will be ignored.
+- Extraction: settings about extraction
+- Extraction.Path: path to which the data file is saved
+- Extraction.FileName: filename of the data file, {} will be replaced with datetime of extraction
+- Extraction.Filter: only messages containing filter are saved while others are ignored. Not effective when partition list has 1 and offset list is not empty. If not specified or not effective, no messages will be ignored.
+- Extraction.MessageWriteBufferSize: capacity of write buffer. The unit is count of messages. Once the buffer is full, messages in the buffer are written to file and then the buffer is cleared.
+- Extraction.MaxMessageFileSize: max file size of message file. The unit is byte. Once a message file size reaches or exceeds the number, a new message file is used to store remaining unsaved messages.
+- Extraction.TimeAfter: Messages with timestamp after the specified time are extracted. Otherwise they are ignored. If empty or invalid, the time is 0001-01-01.
+- Extraction.MaxConcurrentTasks: the number of tasks concurrently running to consume messages from Kafka. It is effective when it is 2 or more and not greater than partition count.
 
-Kafka: settings about Kafka
-Kafka.brokerlist: broker servers, also called Bootstrap Servers
-Kafka.topic: topic from which messages are retrieved
-Kafka.partitionlist: partition list for the tool to retrieve messages, if empty, all partitions will be in the list
-Kafka.offsetlist: Offset is one in a partition not a topic. Offset list is one for the tool to retrieve messages in partition list from specified offsets. If empty or partition list has more than 1, the setting will not be effective and messages will be extracted from beginning in a partition.
+- Kafka: settings about Kafka
+- Kafka.brokerlist: broker servers, also called Bootstrap Servers
+- Kafka.topic: topic from which messages are retrieved
+- Kafka.partitionlist: partition list for the tool to retrieve messages, if empty, all partitions will be in the list
+- Kafka.offsetlist: Offset is one in a partition not a topic. Offset list is one for the tool to retrieve messages in partition list from specified offsets. If empty or partition list has more than 1, the setting will not be effective and messages will be extracted from beginning in a partition.
 
 setting snippet sample:
 
@@ -23,7 +27,11 @@ setting snippet sample:
   "Extraction": {
     "Path": ".\\extraction",
     "FileName": "Extraction{0:yyyyMMddHHmmss}.txt",
-    "Filter": "50chn"
+    "Filter": "50chn",
+    "MessageWriteBufferSize": 5000,
+    "MaxMessageFileSize": 1073741824,
+    "TimeAfter": "2020-01-01",
+    "MaxConcurrentTasks": 8
   },
   "Kafka": {
     "brokerlist": "10.253.204.36:9092,10.253.204.37:9092,10.253.204.38:9092",
@@ -32,3 +40,9 @@ setting snippet sample:
     "offsetlist": "1001,2002,3003,4004"
   }
 ```
+## Change Log
+
+- 2019-11-20 First stable version
+- 2020-04-16 Asynchronously write messages to file. Once the message file size reaches or exceeds the specified number, messages are written to another file.
+- 2020-06-18 Able to consume messages with timestamp after the specified time.
+- 2020-07-15 Update denpendencies to their latest version. Add setting items to set write buffer size, max message file size and max concurrent task count.

--- a/KafkaExtractor/appsettings.json
+++ b/KafkaExtractor/appsettings.json
@@ -18,7 +18,11 @@
   "Extraction": {
     "Path": "",
     "FileName": "Extraction{0:yyyyMMddHHmmss}.txt",
-    "Filter": ""
+    "Filter": "",
+    "MessageWriteBufferSize": 5000,
+    "MaxMessageFileSize": 1073741824,
+    "TimeAfter": "2020-01-01",
+    "MaxConcurrentTasks": 8
   },
   "Kafka": {
     "brokerlist": "10.253.204.36:9092,10.253.204.37:9092,10.253.204.38:9092",

--- a/KafkaSpout/KafkaSpout.csproj
+++ b/KafkaSpout/KafkaSpout.csproj
@@ -6,11 +6,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="1.2.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.0.1" />
+    <PackageReference Include="Confluent.Kafka" Version="1.4.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.6" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.6" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.6" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.6" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
-# kafkatool
+# KafkaTool
 A set of Kafka tools written with .net Core
+
+## KafkaExtractor
+A tool to extract Kafka messages. User can specify topic, partitions, offsets and filter for extraction.
+
+## KafkaSpout
+A tool to produce data to Kafka. User can generate message key with specified rules.
+
+## Note
+Check README.md in each tool.


### PR DESCRIPTION
- 2020-04-16 Asynchronously write messages to file. Once the message file size reaches or exceeds the specified number, messages are written to another file.
- 2020-06-18 Able to consume messages with timestamp after the specified time.
- 2020-07-15 Update denpendencies to their latest version. Add setting items to set write buffer size, max message file size and max concurrent task count.